### PR TITLE
Fix crash caused by fixed size collection.

### DIFF
--- a/CSG.Sharp.Lib/Primitives/Node.cs
+++ b/CSG.Sharp.Lib/Primitives/Node.cs
@@ -71,7 +71,7 @@ namespace CSG.Sharp
             if (_back != null) back = _back.ClipPolygons(back).ToList();
             else back = Enumerable.Empty<Polygon>().ToList();
 
-            return front.Concat(back).ToArray();
+            return front.Concat(back).ToList();
         }
 
         // Remove all polygons in this BSP tree that are inside the other BSP tree


### PR DESCRIPTION
In some cases this variables will be accessed by Plane.SplitPolygon() and at it will crash, because the Collection is fixed size, so cannot use Add() 

  switch (polygonType)
  {
      case COPLANAR:
          (_normal.Dot(polygon.Plane._normal) > 0 ? coplanarFront : coplanarBack).Add(polygon);
          break;
 ...
}